### PR TITLE
bugfix: remove deprecated Squiz.WhiteSpace.LanguageConstructSpacing

### DIFF
--- a/Abyss/ruleset.xml
+++ b/Abyss/ruleset.xml
@@ -225,9 +225,6 @@
         <message>Variable "%s" not allowed in double-quoted string; use sprintf() or concatenation instead</message>
     </rule>
 
-    <!-- Require space after language constructs -->
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
-
     <!-- Require space around logical operators -->
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
 


### PR DESCRIPTION
see [1953](https://github.com/squizlabs/PHP_CodeSniffer/issues/1953)